### PR TITLE
Fix exec_command failing on any command with arguments

### DIFF
--- a/src/mcp_proxmox/client.py
+++ b/src/mcp_proxmox/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 from typing import Any, cast
 
 from proxmoxer import ProxmoxAPI  # type: ignore[import-untyped]
@@ -194,9 +195,13 @@ class ProxmoxClient:
 
     def exec_qemu_agent(self, node: str, vmid: int, command: str) -> dict[str, Any]:
         """Execute a command via QEMU guest agent. Returns the PID."""
+        # The Proxmox API expects `command` as an array (program + each argument
+        # as a separate element), not a single string. Passing a raw string with
+        # spaces breaks the request (manifests as a broken-pipe/TLS error).
+        args = shlex.split(command)
         return cast(
             dict[str, Any],
-            self.api.nodes(node).qemu(vmid).agent.exec.post(command=command),
+            self.api.nodes(node).qemu(vmid).agent.exec.post(command=args),
         )
 
     def exec_qemu_agent_status(self, node: str, vmid: int, pid: int) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- `exec_qemu_agent()` in `client.py` passed the raw `command` string directly to the Proxmox VE `/agent/exec` API endpoint.
- That endpoint expects `command` as an **array** (the executable followed by each argument as a separate element), not a single string.
- As a result, any command containing a space (i.e. anything with arguments) failed with an opaque TLS-negotiation/broken-pipe style error. Single-word commands like `hostname` or `whoami` happened to work since they're valid as a one-element array.

## Fix
Split the command string with `shlex` before sending it to the API.

## Test plan
- [x] Reproduced the bug against a live Proxmox cluster: `whoami`/`hostname`/`pwd` (no args) succeeded, `ls -la`/`systemctl is-active foo`/`echo hello` all failed with the broken-pipe error.
- [x] Applied the fix and confirmed multi-word commands (e.g. `systemctl is-active <service>`) now execute correctly and return proper stdout/exit codes.