### PR TITLE
fix: use standalone fastmcp.FastMCP for mcp-proxy SSE compatibility

### DIFF
--- a/src/mcp_proxmox/server.py
+++ b/src/mcp_proxmox/server.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from mcp_proxmox.client import ProxmoxClient
 from mcp_proxmox.config import ProxmoxConfig


### PR DESCRIPTION
## Problem
`mcp.server.fastmcp.FastMCP` (MCP SDK built-in) is incompatible with mcp-proxy SSE transport. Tool calls fail with `ClosedResourceError` and the proxy logs show `RuntimeError: Expected ASGI message 'http.response.body', but got 'http.response.start'`.

The same server works fine over direct stdio transport, and other servers using standalone `fastmcp.FastMCP` (like freee MCP) work perfectly through mcp-proxy SSE.

## Fix
Replace `from mcp.server.fastmcp import FastMCP` with `from fastmcp import FastMCP`.

The standalone `fastmcp` package (already a dependency of the MCP SDK) has a more robust transport layer that handles SSE proxying correctly. This is the same FastMCP used by other working servers.

## Testing
Verified with mcp-proxy v0.12.0 SSE transport:
- `list_nodes` ✅
- `list_containers` ✅ (10 containers returned)
- `get_node_status` ✅ (full node info)
- `get_guest_status` ✅
- No ASGI errors in proxy logs
- No ClosedResourceError on tool calls