### PR TITLE
fix: pin mcp<2 and add server import smoke test (v1.2.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,10 @@ A 403 usually means the API token is valid but does not have enough Proxmox priv
 
 `exec_command` only works for QEMU VMs with `qemu-guest-agent` installed and running inside the guest. If the tool reports that the QEMU guest agent is not responding, start or install the agent in the VM and retry. LXC containers are not supported by this Proxmox API path, so use another container access method instead.
 
+### `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`
+
+The MCP Python SDK 2.0 removed the `mcp.server.fastmcp` module that mcp-proxmox 1.2.1 and earlier import. Fresh installs (`uvx mcp-proxmox`, `uv tool install`, `pip install`) resolved `mcp` 2.x and failed on startup — in Claude Desktop this only shows up as "Server disconnected". Upgrade to mcp-proxmox 1.2.2 or later, which pins `mcp<2`. If you must stay on an older mcp-proxmox, constrain the SDK yourself: `uvx --with "mcp<2" mcp-proxmox`.
+
 ### Self-signed certificate or connection errors
 
 Proxmox commonly runs on port `8006`, so check that `PROXMOX_HOST` and `PROXMOX_PORT` point to the same endpoint you use for the Proxmox web UI. For homelab clusters with self-signed certificates, leave `PROXMOX_VERIFY_SSL=false` or set it explicitly. Use `PROXMOX_VERIFY_SSL=true` only when the Proxmox certificate chains to a CA trusted by your runtime.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,6 +14,7 @@
 - [ ] `move_disk` — move disk between storages
 
 ## Future Ideas
+- Migrate to the MCP Python SDK 2.x API (`mcp.server.fastmcp` was removed in `mcp` 2.0; 1.2.2 pins `mcp<2` as the interim fix)
 - ACL/permissions management (list_permissions, add_permission)
 - Cluster status (nodes, quorum, corosync health)
 - SPICE/VNC console URL generation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-proxmox"
-version = "1.2.1"
+version = "1.2.2"
 description = "MCP server for managing Proxmox VE clusters through AI assistants"
 readme = "README.md"
 license = "MIT"
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "mcp>=1.26.0",
+    "mcp>=1.26.0,<2",
     "proxmoxer>=2.1.0",
     "requests>=2.31.0",
     "python-dotenv>=1.0.0",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/antonio-mello-ai/mcp-proxmox",
     "source": "github"
   },
-  "version": "1.2.1",
+  "version": "1.2.2",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "mcp-proxmox",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -114,3 +114,23 @@ def test_exec_command_timeout(mock_client):
 
     assert result["status"] == "running"
     assert result["pid"] == 44
+
+
+def test_exec_command_sends_arguments_as_array(mock_client):
+    """The /agent/exec endpoint expects `command` as an array (program + args)."""
+    mock_client._api.cluster.resources.get.return_value = SAMPLE_CLUSTER_RESOURCES
+    mock_client._api.nodes("pve").qemu(100).agent.exec.post.return_value = {"pid": 44}
+    mock_client._api.nodes("pve").qemu(100).agent("exec-status").get.return_value = {
+        "exited": 1,
+        "exitcode": 0,
+        "out-data": "active\n",
+        "err-data": "",
+    }
+
+    with patch("mcp_proxmox.tools.execute.time.sleep"):
+        result = exec_command(mock_client, 100, "systemctl is-active 'my service'")
+
+    assert result["success"] is True
+    mock_client._api.nodes("pve").qemu(100).agent.exec.post.assert_called_once_with(
+        command=["systemctl", "is-active", "my service"]
+    )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,27 @@
+"""Smoke tests for the MCP server module.
+
+The unit tests exercise the tool functions directly, so nothing else imports
+``mcp_proxmox.server``. These tests make sure the server module — and the
+MCP SDK API it depends on — still imports and registers every tool. This is
+what breaks when the ``mcp`` package ships an incompatible major version
+(see issue #13: ``mcp`` 2.0.0 removed ``mcp.server.fastmcp``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from mcp_proxmox import server
+
+
+def test_server_module_imports() -> None:
+    assert server.mcp.name == "mcp-proxmox"
+
+
+def test_server_registers_tools() -> None:
+    tools = asyncio.run(server.mcp.list_tools())
+    names = {tool.name for tool in tools}
+
+    assert len(names) == 34
+    for expected in ("list_vms", "exec_command", "create_snapshot", "migrate_guest"):
+        assert expected in names

--- a/uv.lock
+++ b/uv.lock
@@ -492,7 +492,7 @@ wheels = [
 
 [[package]]
 name = "mcp-proxmox"
-version = "0.4.0"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -512,7 +512,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mcp", specifier = ">=1.26.0" },
+    { name = "mcp", specifier = ">=1.26.0,<2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "proxmoxer", specifier = ">=2.1.0" },


### PR DESCRIPTION
## Why

`mcp` 2.0.0 (2026-07-28) removed `mcp.server.fastmcp`. `pyproject.toml` declared `mcp>=1.26.0` with no upper bound, so every fresh install (`uvx mcp-proxmox`, `uv tool install`, `pip install`) picked 2.0.0 and crashed on import — reported in #13. The unit tests exercise the tool functions directly and never import `mcp_proxmox.server`, which is why CI stayed green.

## What

- Pin `mcp>=1.26.0,<2`. Migrating to the 2.x server API is a separate change (noted in ROADMAP).
- `tests/test_server.py`: imports the server module and asserts all 34 tools are registered. Verified locally that this test fails with `mcp==2.0.0` installed and passes with 1.29.0.
- Regression test for the `exec_command` argument-splitting fix from #10.
- Bump to 1.2.2 (`pyproject.toml`, `server.json`, `uv.lock`).
- README Troubleshooting entry for the `ModuleNotFoundError`.

## Release

Merging this is followed by the `v1.2.2` GitHub release, which triggers the PyPI + GHCR publish workflows.

Fixes #13